### PR TITLE
Add DISTRO_VERSION in Cirrus CI configuration for correct naming of i…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,16 +36,16 @@ build_task_template: &BUILD_TASK_TEMPLATE
   build_script: |
     cd image-builder/images/capi
     export PATH=$PWD/.bin:$HOME/.local/bin:$PATH
-    make build-qemu-ubuntu-2204
+    make build-qemu-ubuntu-$DISTRO_VERSION
 
   prepare_push_script: |
-    pushd image-builder/images/capi/output/ubuntu-2204-kube-v$IMAGE_IDENTIFIER
+    pushd image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER
     find . -type f -execdir bash -c 'x={}; cp $x ${x%.*}.qcow2; mv $x $x.qcow2' \;
     find . -name '*.qcow2' -execdir bash -c 'x={}; sha256sum $(basename $x) > $x.CHECKSUM' \;
-    find . -name "*$IMAGE_IDENTIFIER.*.qcow2" -execdir bash -c 'x={}; echo $(date +%Y-%m-%d) ubuntu-2204-kube-v$IMAGE_IDENTIFIER/$(basename $x) > last-$IMAGE_IDENTIFIER' \;
+    find . -name "*$IMAGE_IDENTIFIER.*.qcow2" -execdir bash -c 'x={}; echo $(date +%Y-%m-%d) ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/$(basename $x) > last-$IMAGE_IDENTIFIER' \;
     ls -lah
     popd
-    mv image-builder/images/capi/output/ubuntu-2204-kube-v$IMAGE_IDENTIFIER/last-$IMAGE_IDENTIFIER .
+    mv image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/last-$IMAGE_IDENTIFIER .
     cat last-$IMAGE_IDENTIFIER
 
   push_script: |
@@ -63,6 +63,7 @@ build_131_task:
   skip: "!changesInclude('extra_vars_131.json', '.cirrus.yml')"
   env:
     IMAGE_IDENTIFIER: "1.31"
+    DISTRO_VERSION: "2204"
     PACKER_VAR_FILES: ../../../extra_vars_131.json
 
 build_132_task:
@@ -70,6 +71,7 @@ build_132_task:
   skip: "!changesInclude('extra_vars_132.json', '.cirrus.yml')"
   env:
     IMAGE_IDENTIFIER: "1.32"
+    DISTRO_VERSION: "2204"
     PACKER_VAR_FILES: ../../../extra_vars_132.json
 
 build_133_task:
@@ -77,6 +79,7 @@ build_133_task:
   skip: "!changesInclude('extra_vars_133.json', '.cirrus.yml')"
   env:
     IMAGE_IDENTIFIER: "1.33"
+    DISTRO_VERSION: "2404"
     PACKER_VAR_FILES: ../../../extra_vars_133.json
 
 build_134_task:
@@ -84,4 +87,5 @@ build_134_task:
   skip: "!changesInclude('extra_vars_134.json', '.cirrus.yml')"
   env:
     IMAGE_IDENTIFIER: "1.34"
+    DISTRO_VERSION: "2404"
     PACKER_VAR_FILES: ../../../extra_vars_134.json


### PR DESCRIPTION
Hello,

Since you also create Ubuntu 24.04 images, the naming of the images with Ubuntu 22.04 has remained unchanged.
Example: ubuntu-2404-kube-v1.33.4.qcow2 is saved as ubuntu-2204-kube-v1.33.4.qcow2.

With this pull request, I have added an environment variable to .cirrus.yaml for each K8S version to name the images with the correct distribution version.