### PR TITLE
Add Kubernetes v1.35 support and fix last-X file version reference

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,9 +42,10 @@ build_task_template: &BUILD_TASK_TEMPLATE
     pushd image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER
     find . -type f -execdir bash -c 'x={}; cp $x ${x%.*}.qcow2; mv $x $x.qcow2' \;
     find . -name '*.qcow2' -execdir bash -c 'x={}; sha256sum $(basename $x) > $x.CHECKSUM' \;
-    #find . -name "*$IMAGE_IDENTIFIER.*.qcow2" -execdir bash -c 'x={}; echo $(date +%Y-%m-%d) ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/$(basename $x) > last-$IMAGE_IDENTIFIER' \;
-    FIRST_QCOW2=$(find . -name '*.qcow2' -print -quit 2>/dev/null)
-    echo "$(date +%Y-%m-%d) ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/$(basename "$FIRST_QCOW2")" > "last-$IMAGE_IDENTIFIER"
+    VARS_FILE_SUFFIX=${IMAGE_IDENTIFIER//.}
+    VARS_FILE_SUFFIX=${VARS_FILE_SUFFIX//-/_}
+    KUBERNETES_SEMVER=$(jq -r '.kubernetes_semver' $CIRRUS_WORKING_DIR/extra_vars_${VARS_FILE_SUFFIX}.json)
+    echo "$(date +%Y-%m-%d) ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/ubuntu-$DISTRO_VERSION-kube-$KUBERNETES_SEMVER.qcow2" > "last-$IMAGE_IDENTIFIER"
     ls -lah
     popd
     mv image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/last-$IMAGE_IDENTIFIER .
@@ -91,3 +92,11 @@ build_134_task:
     IMAGE_IDENTIFIER: "1.34"
     DISTRO_VERSION: "2404"
     PACKER_VAR_FILES: ../../../extra_vars_134.json
+
+build_135_task:
+  <<: *BUILD_TASK_TEMPLATE
+  skip: "!changesInclude('extra_vars_135.json', '.cirrus.yml')"
+  env:
+    IMAGE_IDENTIFIER: "1.35"
+    DISTRO_VERSION: "2404"
+    PACKER_VAR_FILES: ../../../extra_vars_135.json

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ contains, for example, version `1.27.3`.
 
 ## Kubernetes Versions
 
-| Series | Current Version | Image URL                                                                                                                                                | End of Active Support                           | End of Maintenance Support                      |
-|--------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|-------------------------------------------------|
-| v1.34  | v1.34.3         | [ubuntu-2404-kube-v1.34.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.qcow2)  | [2026-12-28](https://endoflife.date/kubernetes) | [2027-04-28](https://endoflife.date/kubernetes) |
-| v1.33  | v1.33.7         | [ubuntu-2404-kube-v1.33.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.qcow2)  | [2026-04-28](https://endoflife.date/kubernetes) | [2026-06-28](https://endoflife.date/kubernetes) |
-| v1.32  | v1.32.11        | [ubuntu-2204-kube-v1.32.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2204-kube-v1.32/ubuntu-2204-kube-v1.32.qcow2)  | [2025-12-28](https://endoflife.date/kubernetes) | [2026-02-28](https://endoflife.date/kubernetes) |
+| Series | Current Version | Image URL                                                                                                                                                | End of Life |
+|--------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| v1.35  | v1.35.0         | [ubuntu-2404-kube-v1.35.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.35/ubuntu-2404-kube-v1.35.qcow2)  | 2027-02-28  |
+| v1.34  | v1.34.3         | [ubuntu-2404-kube-v1.34.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.qcow2)  | 2026-10-27  |
+| v1.33  | v1.33.7         | [ubuntu-2404-kube-v1.33.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.qcow2)  | 2026-06-28  |
+| v1.32  | v1.32.11        | [ubuntu-2204-kube-v1.32.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2204-kube-v1.32/ubuntu-2204-kube-v1.32.qcow2)  | 2026-02-28  |
 
 ## Determining Current Versions
 
@@ -35,6 +36,7 @@ The files are available at:
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.32
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.33
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.34
+https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.35
 ```
 
 Each file contains a single line in the format:

--- a/extra_vars_135.json
+++ b/extra_vars_135.json
@@ -1,0 +1,8 @@
+{
+    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "kubernetes_deb_version": "1.35.0-1.1",
+    "kubernetes_semver": "v1.35.0",
+    "kubernetes_series": "v1.35",
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_series`}}"
+}


### PR DESCRIPTION
- Add build configuration for Kubernetes v1.35 with Ubuntu 24.04
- Simplify README table by merging EOL columns into single "End of Life"
- Fix last-X files to reference current version (e.g., v1.34.3) instead of series version (e.g., v1.34) by extracting kubernetes_semver from extra_vars JSON

AI-assisted: Claude Code