### PR TITLE
Add Kubernetes v1.36 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,3 +119,19 @@ build_135_gardener_task:
     IMAGE_IDENTIFIER: "1.35-gardener"
     DISTRO_VERSION: "2404"
     PACKER_VAR_FILES: ../../../extra_vars_135_gardener.json
+
+build_136_task:
+  <<: *BUILD_TASK_TEMPLATE
+  skip: "!changesInclude('extra_vars_136.json', '.cirrus.yml')"
+  env:
+    IMAGE_IDENTIFIER: "1.36"
+    DISTRO_VERSION: "2404"
+    PACKER_VAR_FILES: ../../../extra_vars_136.json
+
+build_136_gardener_task:
+  <<: *BUILD_TASK_TEMPLATE
+  skip: "!changesInclude('extra_vars_136_gardener.json', '.cirrus.yml')"
+  env:
+    IMAGE_IDENTIFIER: "1.36-gardener"
+    DISTRO_VERSION: "2404"
+    PACKER_VAR_FILES: ../../../extra_vars_136_gardener.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ contains, for example, version `1.27.3`.
 
 | Series | Current Version | Image URL                                                                                                                                                | End of Life |
 |--------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| v1.36  | v1.36.0         | [ubuntu-2404-kube-v1.36.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.36/ubuntu-2404-kube-v1.36.qcow2)  | 2027-06-28  |
 | v1.35  | v1.35.4         | [ubuntu-2404-kube-v1.35.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.35/ubuntu-2404-kube-v1.35.qcow2)  | 2027-02-28  |
 | v1.34  | v1.34.7         | [ubuntu-2404-kube-v1.34.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.qcow2)  | 2026-10-27  |
 | v1.33  | v1.33.11        | [ubuntu-2404-kube-v1.33.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.qcow2)  | 2026-06-28  |
@@ -35,6 +36,7 @@ The files are available at:
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.33
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.34
 https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.35
+https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/last-1.36
 ```
 
 Each file contains a single line in the format:

--- a/extra_vars_136.json
+++ b/extra_vars_136.json
@@ -1,0 +1,8 @@
+{
+    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "kubernetes_deb_version": "1.36.0-1.1",
+    "kubernetes_semver": "v1.36.0",
+    "kubernetes_series": "v1.36",
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_series`}}"
+}

--- a/extra_vars_136_gardener.json
+++ b/extra_vars_136_gardener.json
@@ -1,0 +1,12 @@
+{
+    "containerd_sha256": "ca0f27e34411504acd1cd24fcbaa71b9c47d31ce9408c47c54a2dc1810ceb1df",
+    "containerd_version": "1.7.30",
+    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "kubernetes_deb_version": "1.36.0-1.1",
+    "kubernetes_semver": "v1.36.0",
+    "kubernetes_series": "v1.36",
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_series`}}-gardener",
+    "runc_sha256": "c5d4995c5aec204d7e1827d9d9a6b45042602736f7f415f484252e576dcdac28",
+    "runc_version": "1.4.0"
+}


### PR DESCRIPTION
- Add extra_vars_136.json and extra_vars_136_gardener.json (Ubuntu 24.04, kubernetes_deb_version 1.36.0-1.1)
- Add build_136_task and build_136_gardener_task to .cirrus.yml
- README: list v1.36.0 (EOL 2027-06-28) and last-1.36 URL

AI-assisted: Claude Code