### PR TITLE
Use Ubuntu 24.04.4 ISO image

### DIFF
--- a/extra_vars_133.json
+++ b/extra_vars_133.json
@@ -1,6 +1,6 @@
 {
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.33.12-1.1",
     "kubernetes_semver": "v1.33.12",
     "kubernetes_series": "v1.33",

--- a/extra_vars_133_gardener.json
+++ b/extra_vars_133_gardener.json
@@ -1,8 +1,8 @@
 {
     "containerd_sha256": "ca0f27e34411504acd1cd24fcbaa71b9c47d31ce9408c47c54a2dc1810ceb1df",
     "containerd_version": "1.7.30",
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.33.12-1.1",
     "kubernetes_semver": "v1.33.12",
     "kubernetes_series": "v1.33",

--- a/extra_vars_134.json
+++ b/extra_vars_134.json
@@ -1,6 +1,6 @@
 {
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.34.8-1.1",
     "kubernetes_semver": "v1.34.8",
     "kubernetes_series": "v1.34",

--- a/extra_vars_134_gardener.json
+++ b/extra_vars_134_gardener.json
@@ -1,8 +1,8 @@
 {
     "containerd_sha256": "ca0f27e34411504acd1cd24fcbaa71b9c47d31ce9408c47c54a2dc1810ceb1df",
     "containerd_version": "1.7.30",
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.34.8-1.1",
     "kubernetes_semver": "v1.34.8",
     "kubernetes_series": "v1.34",

--- a/extra_vars_135.json
+++ b/extra_vars_135.json
@@ -1,6 +1,6 @@
 {
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.35.5-1.1",
     "kubernetes_semver": "v1.35.5",
     "kubernetes_series": "v1.35",

--- a/extra_vars_135_gardener.json
+++ b/extra_vars_135_gardener.json
@@ -1,8 +1,8 @@
 {
     "containerd_sha256": "ca0f27e34411504acd1cd24fcbaa71b9c47d31ce9408c47c54a2dc1810ceb1df",
     "containerd_version": "1.7.30",
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.35.5-1.1",
     "kubernetes_semver": "v1.35.5",
     "kubernetes_series": "v1.35",

--- a/extra_vars_136.json
+++ b/extra_vars_136.json
@@ -1,6 +1,6 @@
 {
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.36.1-1.1",
     "kubernetes_semver": "v1.36.1",
     "kubernetes_series": "v1.36",

--- a/extra_vars_136_gardener.json
+++ b/extra_vars_136_gardener.json
@@ -1,8 +1,8 @@
 {
     "containerd_sha256": "ca0f27e34411504acd1cd24fcbaa71b9c47d31ce9408c47c54a2dc1810ceb1df",
     "containerd_version": "1.7.30",
-    "iso_checksum": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b",
-    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.3-live-server-amd64.iso",
+    "iso_checksum": "e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433",
+    "iso_url": "https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso",
     "kubernetes_deb_version": "1.36.1-1.1",
     "kubernetes_semver": "v1.36.1",
     "kubernetes_series": "v1.36",


### PR DESCRIPTION
## Summary

Update the Ubuntu base image used for building the k8s-capi images from **24.04.3** to **24.04.4**.

Changed `iso_url` and `iso_checksum` in all `extra_vars_*.json` files:

- `iso_url` → `https://releases.ubuntu.com/releases/noble/ubuntu-24.04.4-live-server-amd64.iso`
- `iso_checksum` → `e907d92eeec9df64163a7e454cbc8d7755e8ddc7ed42f99dbc80c40f1a138433`

The checksum is the official SHA256 from the Ubuntu `noble/SHA256SUMS` file.

## Files changed

- `extra_vars_133.json` / `extra_vars_133_gardener.json`
- `extra_vars_134.json` / `extra_vars_134_gardener.json`
- `extra_vars_135.json` / `extra_vars_135_gardener.json`
- `extra_vars_136.json` / `extra_vars_136_gardener.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)