### PR TITLE
Stand up a DIB-based local build with functional parity to image-builder

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -1,24 +1,52 @@
 #!/bin/bash
+# Build a CAPI image locally with diskimage-builder, reproducing image-builder's
+# ubuntu-2404-kube-vX.YY qcow2 via the k8s-capi element.
+#
+# Usage:
+#   ./build-local.sh [VERSION]
+#
+# VERSION is the basename of an overrides/<VERSION>.json file, e.g.:
+#   ./build-local.sh v1.33
+#   ./build-local.sh v1.36-gardener
+#
+# Environment:
+#   DIB_K8S_IMAGE_BUILDER_REF  image-builder commit SHA to run (default: the
+#                              commit for tag v0.1.52)
+#
+# Requires Linux with root/sudo and qemu/libguestfs; it does not run on macOS.
 
-# Environment variables
-export IMAGE_IDENTIFIER="1.33-gardener"
-export DISTRO_VERSION="2404"
-export PACKER_VAR_FILES="../../../extra_vars_133_gardener.json"
+set -euo pipefail
 
-# Prepare script
-# git clone https://github.com/kubernetes-sigs/image-builder
-# cd image-builder/images/capi
-# export PATH=$PWD/.bin:$HOME/.local/bin:$PATH
-# make deps-qemu
-# make build-qemu-ubuntu-$DISTRO_VERSION
+cd "$(dirname "$0")"
 
-# Prepare push script
-pushd image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER
-find . -type f -execdir bash -c 'x={}; cp $x ${x%.*}.qcow2; mv $x $x.qcow2' \;
-find . -name '*.qcow2' -execdir bash -c 'x={}; sha256sum $(basename $x) > $x.CHECKSUM' \;
-FIRST_QCOW2=$(find . -name '*.qcow2' -print -quit 2>/dev/null)
-echo "$(date +%Y-%m-%d) ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/$(basename "$FIRST_QCOW2")" > "last-$IMAGE_IDENTIFIER"
-ls -lah
-popd
-mv image-builder/images/capi/output/ubuntu-$DISTRO_VERSION-kube-v$IMAGE_IDENTIFIER/last-$IMAGE_IDENTIFIER .
-cat last-$IMAGE_IDENTIFIER
+VERSION="${1:-v1.33}"
+case "${VERSION}" in
+    */*|*..*)
+        echo "ERROR: invalid VERSION '${VERSION}'; it must be an overrides/ basename" >&2
+        exit 1
+        ;;
+esac
+OVERRIDE="overrides/${VERSION}.json"
+if [ ! -f "${OVERRIDE}" ]; then
+    echo "ERROR: no override file ${OVERRIDE}" >&2
+    exit 1
+fi
+
+export DIB_K8S_CAPI_OVERRIDE
+DIB_K8S_CAPI_OVERRIDE="$(readlink -f "${OVERRIDE}")"
+export DIB_RELEASE=noble
+export ELEMENTS_PATH=./elements
+
+SEMVER="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['kubernetes_semver'])" "${OVERRIDE}")"
+NAME="ubuntu-2404-kube-${SEMVER}"
+case "${VERSION}" in
+    *-gardener) NAME="${NAME}-gardener" ;;
+esac
+
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+
+mkdir -p output
+.venv/bin/disk-image-create -a amd64 -t qcow2 \
+    -o "output/${NAME}" \
+    ubuntu vm growroot openssh-server k8s-capi

--- a/elements/k8s-capi/README.rst
+++ b/elements/k8s-capi/README.rst
@@ -1,0 +1,102 @@
+========
+k8s-capi
+========
+
+A diskimage-builder element that reproduces the Cluster API (CAPI)
+``ubuntu-2404-kube-vX.YY`` images locally without Packer. Instead of
+reimplementing the provisioning in Bash, it fetches
+`kubernetes-sigs/image-builder <https://github.com/kubernetes-sigs/image-builder>`_
+at a pinned git ref and runs image-builder's *original* Ansible roles
+(``node`` → ``setup``, ``providers``, ``containerd``, ``kubernetes``,
+``sysprep``) unchanged inside the build chroot.
+
+The central problem this element solves is that image-builder's roles assume a
+booted VM with a running ``systemd``, while the diskimage-builder chroot has no
+init system. The element supplies build-time shims and a ``policy-rc.d`` so the
+daemon-touching tasks succeed while still writing their configuration files, and
+starts ``containerd`` manually for the Kubernetes image pre-pull.
+
+Inputs
+======
+
+Both inputs are environment variables (see ``environment.d/10-k8s-capi.bash``):
+
+``DIB_K8S_IMAGE_BUILDER_REF``
+  Immutable **commit SHA** of ``kubernetes-sigs/image-builder`` to clone and
+  run -- not a tag or branch, since the cloned roles run as root on the build
+  host and ship in every node image. Defaults to the commit for tag ``v0.1.52``
+  (``3428a09fcb4293b22a01a5e32cc007a9dacad6ec``).
+
+``DIB_K8S_CAPI_OVERRIDE``
+  Absolute path to one of the ``overrides/*.json`` files in this repository.
+  It selects the Kubernetes series (and, for the ``-gardener`` variants, the
+  containerd/runc versions). There is no default; the build fails loudly if it
+  is unset or points at a missing file.
+
+Usage
+=====
+
+The element is normally driven through ``build-local.sh`` at the repository
+root, which sets the inputs and invokes::
+
+    disk-image-create -a amd64 -t qcow2 \
+        -o output/ubuntu-2404-kube-v1.33.12 \
+        ubuntu vm growroot openssh-server k8s-capi
+
+How it works
+============
+
+``extra-data.d/10-fetch-image-builder`` (outside the chroot)
+  Clones image-builder at ``DIB_K8S_IMAGE_BUILDER_REF`` and stages, under
+  ``$TMP_HOOKS_PATH/image-builder`` (visible as ``/tmp/in_target.d/image-builder``
+  in the chroot): the ``ansible/`` tree and ``ansible.cfg``, the
+  ``packer/config/*.json`` role inputs, the six build shims, ``wrapper.yml``,
+  and the selected override. It normalizes the config JSONs by rewriting
+  Packer ``{{ user `x` }}`` references to Ansible ``{{ x }}`` and replacing
+  JSON ``null`` with the empty string, so a direct ``ansible-playbook`` run
+  behaves like Packer's variable handling.
+
+``install.d/50-install-ansible`` (in the chroot)
+  Builds a throwaway virtualenv with the ``ansible-core`` version image-builder
+  pins at the chosen ref and installs the ``community.general`` and
+  ``ansible.posix`` collections the roles import.
+
+``install.d/60-run-image-builder`` (in the chroot)
+  Writes ``/usr/sbin/policy-rc.d`` (so apt does not start services), prepends
+  the shims and the venv to ``PATH``, and runs ``wrapper.yml`` with the staged
+  config JSONs and the override.
+
+``cleanup.d/90-k8s-capi-cleanup`` (in the chroot)
+  Removes ``policy-rc.d`` and the Ansible/pip caches so no build scaffolding
+  ships in the image.
+
+Build shims
+===========
+
+``static/shims/`` contains drop-in replacements prepended to ``PATH`` only
+during the Ansible run:
+
+``systemctl``
+  No-ops daemon lifecycle verbs (``start``/``stop``/``restart``/
+  ``daemon-reload`` …) and answers status queries benignly, but performs
+  ``enable``/``disable`` offline (``SYSTEMD_OFFLINE=1``) so ``containerd`` and
+  ``kubelet`` end up enabled-but-stopped in the image.
+
+``modprobe``, ``sysctl``, ``journalctl``, ``fstrim``, ``udevadm``
+  No-op (exit ``0``). The Ansible modules still write their configuration files
+  (``/etc/modules-load.d``, ``/etc/sysctl.conf`` …); only the live kernel/daemon
+  action is skipped.
+
+Offline image pre-pull
+======================
+
+``kubeadm config images pull`` needs a running ``containerd`` so the images bake
+into the offline content store. ``wrapper.yml`` therefore starts
+``/usr/local/bin/containerd`` manually between the ``containerd`` and
+``kubernetes`` roles, waits for its socket, lets the ``kubernetes`` role pull the
+images into the ``k8s.io`` namespace, then stops it.
+
+If the in-chroot ``containerd`` pre-pull proves unstable in a given build
+environment (overlayfs/cgroup constraints), the documented fallback is to pull
+the images on first boot via a ``systemd`` oneshot instead. That fallback is not
+implemented here; the in-chroot pre-pull is the default.

--- a/elements/k8s-capi/cleanup.d/90-k8s-capi-cleanup
+++ b/elements/k8s-capi/cleanup.d/90-k8s-capi-cleanup
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Runs in the chroot at the end of the build. Removes the build scaffolding so
+# the policy-rc.d, the Ansible venv and the pip/galaxy caches do not ship in the
+# image. The image-builder roles' own outputs (binaries, configs, pre-pulled
+# images) live elsewhere on the root filesystem and are kept.
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -euo pipefail
+
+rm -f /usr/sbin/policy-rc.d
+rm -rf /tmp/in_target.d/image-builder
+rm -rf /root/.ansible /root/.cache/pip

--- a/elements/k8s-capi/element-deps
+++ b/elements/k8s-capi/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/elements/k8s-capi/environment.d/10-k8s-capi.bash
+++ b/elements/k8s-capi/environment.d/10-k8s-capi.bash
@@ -1,0 +1,10 @@
+# Immutable commit SHA of kubernetes-sigs/image-builder to fetch and run in the
+# chroot. It MUST be a commit SHA, not a tag or branch: the cloned roles run as
+# root on the build host and are baked into every node image, so a mutable ref
+# could be moved to inject arbitrary code. The default is the commit for tag
+# v0.1.52; override DIB_K8S_IMAGE_BUILDER_REF to pin a different commit.
+export DIB_K8S_IMAGE_BUILDER_REF=${DIB_K8S_IMAGE_BUILDER_REF:-3428a09fcb4293b22a01a5e32cc007a9dacad6ec}
+
+# DIB_K8S_CAPI_OVERRIDE must point at one of the overrides/*.json files and is
+# deliberately left unset here: there is no safe default, so extra-data.d fails
+# loudly when it is missing rather than building an arbitrary Kubernetes series.

--- a/elements/k8s-capi/extra-data.d/10-fetch-image-builder
+++ b/elements/k8s-capi/extra-data.d/10-fetch-image-builder
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Runs outside the chroot. Fetches kubernetes-sigs/image-builder at the pinned
+# ref and stages everything the in-chroot Ansible run needs under
+# $TMP_HOOKS_PATH/image-builder, which appears as /tmp/in_target.d/image-builder
+# inside the chroot.
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -euo pipefail
+
+_ELEM="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ -z "${DIB_K8S_CAPI_OVERRIDE:-}" ]; then
+    echo "ERROR: DIB_K8S_CAPI_OVERRIDE is not set; point it at an overrides/*.json file." >&2
+    exit 1
+fi
+if [ ! -f "${DIB_K8S_CAPI_OVERRIDE}" ]; then
+    echo "ERROR: DIB_K8S_CAPI_OVERRIDE=${DIB_K8S_CAPI_OVERRIDE} does not exist." >&2
+    exit 1
+fi
+
+STAGE="${TMP_HOOKS_PATH}/image-builder"
+rm -rf "${STAGE}"
+mkdir -p "${STAGE}/config"
+
+CLONE="$(mktemp -d)"
+trap 'rm -rf "${CLONE}"' EXIT
+
+# Pin by immutable commit SHA, never a mutable tag/branch: the cloned roles run
+# as root on the build host and are baked into every node image, so a moved
+# upstream ref would be arbitrary code execution. A blobless --no-checkout clone
+# can check out an arbitrary commit without trusting a ref name.
+echo "Cloning kubernetes-sigs/image-builder at ${DIB_K8S_IMAGE_BUILDER_REF} ..."
+git clone --filter=blob:none --no-checkout \
+    https://github.com/kubernetes-sigs/image-builder "${CLONE}"
+git -C "${CLONE}" -c advice.detachedHead=false checkout "${DIB_K8S_IMAGE_BUILDER_REF}"
+
+_CAPI="${CLONE}/images/capi"
+
+# Reuse image-builder's roles unchanged, alongside our wrapper play so role
+# resolution finds roles/ next to the playbook.
+cp -a "${_CAPI}/ansible" "${STAGE}/ansible"
+cp -a "${_CAPI}/ansible.cfg" "${STAGE}/ansible.cfg"
+cp -a "${_ELEM}/static/wrapper.yml" "${STAGE}/ansible/wrapper.yml"
+
+# The role-input config files image-builder loads for a node build (minus the
+# Packer-only goss/ansible-args plumbing).
+for f in common containerd cni kubernetes wasm-shims additional_components \
+    ecr_credential_provider; do
+    cp -a "${_CAPI}/packer/config/${f}.json" "${STAGE}/config/${f}.json"
+done
+
+cp -a "${_ELEM}/static/shims" "${STAGE}/shims"
+chmod +x "${STAGE}/shims/"*
+cp -a "${DIB_K8S_CAPI_OVERRIDE}" "${STAGE}/override.json"
+
+# Normalize the config JSONs so a plain ansible-playbook run matches Packer's
+# variable handling: rewrite Packer {{ user `x` }} to Ansible {{ x }} and turn
+# JSON null into "" (e.g. containerd_additional_settings is b64decoded and would
+# fail on None).
+python3 - "${STAGE}/config/"*.json <<'PYEOF'
+import json
+import pathlib
+import re
+import sys
+
+pat = re.compile(r"\{\{\s*user\s*`([A-Za-z0-9_]+)`\s*\}\}")
+
+
+def norm(value):
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return pat.sub(r"{{ \1 }}", value)
+    return value
+
+
+for arg in sys.argv[1:]:
+    path = pathlib.Path(arg)
+    data = json.loads(path.read_text())
+    data = {key: norm(val) for key, val in data.items()}
+    path.write_text(json.dumps(data, indent=2) + "\n")
+PYEOF
+
+# Pin the exact ansible-core version image-builder uses at this ref. Fail loudly
+# instead of guessing a default if detection breaks (renamed variable or moved
+# file), so the build can never silently run on a mismatched ansible-core.
+ABV="$(grep -oE '_version_ansible_core="[0-9.]+"' \
+    "${_CAPI}/hack/utils.sh" \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+if [ -z "${ABV}" ]; then
+    echo "ERROR: could not detect ansible-core version from image-builder hack/utils.sh" >&2
+    exit 1
+fi
+echo "${ABV}" > "${STAGE}/ansible-core-version"
+
+echo "Staged image-builder (${DIB_K8S_IMAGE_BUILDER_REF}) for the chroot run."

--- a/elements/k8s-capi/install.d/50-install-ansible
+++ b/elements/k8s-capi/install.d/50-install-ansible
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Runs in the chroot. Builds a throwaway virtualenv with the ansible-core version
+# image-builder pins at the chosen ref and the collections its roles import.
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -euo pipefail
+
+STAGE=/tmp/in_target.d/image-builder
+ANSIBLE_CORE_VERSION="$(cat "${STAGE}/ansible-core-version" 2>/dev/null || true)"
+if [ -z "${ANSIBLE_CORE_VERSION}" ]; then
+    echo "ERROR: ${STAGE}/ansible-core-version is missing or empty" >&2
+    exit 1
+fi
+
+python3 -m venv "${STAGE}/venv"
+"${STAGE}/venv/bin/pip" install --no-cache-dir "ansible-core==${ANSIBLE_CORE_VERSION}"
+# Pin collections to exact versions so two builds from the same source produce
+# the same image and a yanked or tampered release cannot silently change what
+# runs as root in the chroot. Both are compatible with ansible-core 2.18.
+"${STAGE}/venv/bin/ansible-galaxy" collection install \
+    'community.general:==12.0.0' \
+    'ansible.posix:==2.2.0'

--- a/elements/k8s-capi/install.d/60-run-image-builder
+++ b/elements/k8s-capi/install.d/60-run-image-builder
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Runs in the chroot. Drives image-builder's roles through wrapper.yml with the
+# build shims on PATH and a policy-rc.d in place, so daemon-touching tasks
+# succeed in the systemd-less chroot while still writing their config files.
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -euo pipefail
+
+STAGE=/tmp/in_target.d/image-builder
+
+# Stop apt from starting services while packages are installed in the chroot.
+cat > /usr/sbin/policy-rc.d <<'EOF'
+#!/bin/sh
+exit 101
+EOF
+chmod 0755 /usr/sbin/policy-rc.d
+
+export ANSIBLE_CONFIG="${STAGE}/ansible.cfg"
+export PATH="${STAGE}/shims:${STAGE}/venv/bin:${PATH}"
+
+cd "${STAGE}"
+
+# The override is loaded last so its Kubernetes/containerd/runc versions win.
+# containerd_service_url, packer_builder_type and packer_build_name are the
+# Packer user-vars the roles need that are not in the config files. python_path
+# is intentionally not passed: wrapper.yml omits PYTHONPATH via default(omit),
+# because an empty value would add the staging dir to root's sys.path.
+ansible-playbook -i 'localhost,' -c local ansible/wrapper.yml \
+    -e @config/common.json \
+    -e @config/containerd.json \
+    -e @config/cni.json \
+    -e @config/kubernetes.json \
+    -e @config/wasm-shims.json \
+    -e @config/additional_components.json \
+    -e @config/ecr_credential_provider.json \
+    -e @override.json \
+    -e packer_builder_type=openstack \
+    -e packer_build_name=openstack \
+    -e 'containerd_service_url=https://raw.githubusercontent.com/containerd/containerd/refs/tags/v{{ containerd_version }}/containerd.service'
+
+# image-builder's containerd role downloads containerd.service over HTTPS with no
+# checksum and installs it as the root-run containerd unit on every node. Gate the
+# shipped unit against the known-good upstream hashes so a tampered or moved tag
+# cannot inject an arbitrary systemd unit into the image. Extend the allowlist
+# when the pinned containerd version changes.
+unit=/etc/systemd/system/containerd.service
+actual="$(sha256sum "${unit}" | awk '{print $1}')"
+case "${actual}" in
+    # containerd 1.7.x (gardener overrides)
+    68dc82b2e67ecb77c8ae7f49ce9681380e80977a1f261a8653e535932cf6400d) ;;
+    # containerd 2.2.2 (image-builder default)
+    1941362cbaa89dd591b99c32b050d82c583d3cd2e5fa63085d7017457ec5fca8) ;;
+    *)
+        echo "ERROR: ${unit} sha256 ${actual} is not in the pinned allowlist" >&2
+        exit 1
+        ;;
+esac

--- a/elements/k8s-capi/package-installs.yaml
+++ b/elements/k8s-capi/package-installs.yaml
@@ -1,0 +1,12 @@
+---
+# Packages required in the chroot before the in-chroot Ansible run.
+# git clones image-builder, python3/pip/venv build the Ansible venv,
+# python3-apt/gnupg back the apt and apt_key modules the roles use.
+ca-certificates:
+curl:
+git:
+gnupg:
+python3:
+python3-apt:
+python3-pip:
+python3-venv:

--- a/elements/k8s-capi/static/shims/fstrim
+++ b/elements/k8s-capi/static/shims/fstrim
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Build-time fstrim shim: discarding blocks is meaningless in the chroot. No-op
+# so the fstrim service task reports success.
+exit 0

--- a/elements/k8s-capi/static/shims/journalctl
+++ b/elements/k8s-capi/static/shims/journalctl
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Build-time journalctl shim: there is no journal to rotate or vacuum in the
+# chroot. No-op so sysprep's log-cleanup tasks report success.
+exit 0

--- a/elements/k8s-capi/static/shims/modprobe
+++ b/elements/k8s-capi/static/shims/modprobe
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build-time modprobe shim: kernel modules cannot be loaded in the chroot, but
+# the roles still persist them to /etc/modules-load.d. No-op so the load step
+# reports success.
+exit 0

--- a/elements/k8s-capi/static/shims/sysctl
+++ b/elements/k8s-capi/static/shims/sysctl
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build-time sysctl shim: runtime kernel parameters cannot be applied in the
+# chroot, but the ansible.posix.sysctl module still writes the sysctl file. No-op
+# so the apply/reload step reports success.
+exit 0

--- a/elements/k8s-capi/static/shims/systemctl
+++ b/elements/k8s-capi/static/shims/systemctl
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Build-time systemctl shim for the systemd-less diskimage-builder chroot.
+#
+# image-builder's roles drive systemctl to enable/start daemons, but the chroot
+# has no running init. This shim lets those tasks succeed while still producing
+# the right on-disk state:
+#   * enable/disable are performed offline (SYSTEMD_OFFLINE=1) so units such as
+#     containerd and kubelet end up enabled in the image;
+#   * lifecycle verbs (start/stop/restart/daemon-reload/...) are no-ops;
+#   * status queries answer benignly so service_facts/package_facts keep working.
+set -u
+
+REAL=/bin/systemctl
+[ -x "$REAL" ] || REAL=/usr/bin/systemctl
+
+# The subcommand is the first non-option argument.
+cmd=""
+for arg in "$@"; do
+    case "$arg" in
+        -*) ;;
+        *) cmd="$arg"; break ;;
+    esac
+done
+
+case "$cmd" in
+    enable|disable|reenable|preset|preset-all|mask|unmask|link|set-default)
+        # Offline file operations work without a running manager, but they must
+        # actually succeed: `enable` has to create the *.wants/ symlinks, or
+        # containerd and kubelet would ship disabled and never start on the node.
+        # Propagate the real exit code instead of swallowing it.
+        exec env SYSTEMD_OFFLINE=1 "$REAL" "$@"
+        ;;
+    is-active|is-failed)
+        echo "inactive"
+        exit 0
+        ;;
+    is-enabled|status|show|cat|list-units|list-unit-files|list-timers|get-default)
+        SYSTEMD_OFFLINE=1 "$REAL" "$@" 2>/dev/null || true
+        exit 0
+        ;;
+    *)
+        # start, stop, restart, reload, daemon-reload, daemon-reexec, ... -> no-op.
+        exit 0
+        ;;
+esac

--- a/elements/k8s-capi/static/shims/udevadm
+++ b/elements/k8s-capi/static/shims/udevadm
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Build-time udevadm shim: there is no udev daemon to query or trigger in the
+# chroot. No-op so tasks that poke udev report success.
+exit 0

--- a/elements/k8s-capi/static/wrapper.yml
+++ b/elements/k8s-capi/static/wrapper.yml
@@ -1,0 +1,86 @@
+# Wrapper play for the diskimage-builder chroot.
+#
+# It mirrors image-builder's images/capi/ansible/node.yml play header (the same
+# hosts/become/vars/environment) and runs the same core roles in the same order
+# -- node (which pulls in setup) -> providers -> containerd -> kubernetes ->
+# sysprep -- so the roles are reused unchanged rather than reimplemented.
+#
+# The only difference from node.yml is the manual containerd start/stop bracket
+# around the kubernetes role: the chroot has no running systemd, so containerd is
+# launched by hand for the kubeadm offline image pre-pull and stopped afterwards.
+# node.yml's optional, gated-off includes (custom roles, load_additional_components,
+# ecr_credential_provider) are dropped because their variables are not loaded.
+---
+- name: Provision node
+  hosts: all
+  become: true
+  vars:
+    system: linux
+    arch_uname: "{{ ansible_facts['architecture'] }}"
+    arch: "{{ {'x86_64': 'amd64', 'amd64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64', 'ppc64le': 'ppc64le'}.get(arch_uname, 'unsupported') }}"
+
+  tasks:
+    - name: Include node role
+      ansible.builtin.include_role:
+        name: node
+    - name: Include providers role
+      ansible.builtin.include_role:
+        name: providers
+    - name: Include containerd role
+      ansible.builtin.include_role:
+        name: containerd
+
+    - name: Pre-pull Kubernetes images with a build-time containerd
+      block:
+        - name: Start containerd in the background for the offline image pre-pull
+          ansible.builtin.shell: |
+            setsid /usr/local/bin/containerd --config /etc/containerd/config.toml \
+              </dev/null >/var/log/containerd-build.log 2>&1 &
+          args:
+            executable: /bin/bash
+          changed_when: true
+        - name: Wait for the containerd socket
+          ansible.builtin.wait_for:
+            path: /var/run/containerd/containerd.sock
+            timeout: 60
+
+        - name: Include kubernetes role
+          ansible.builtin.include_role:
+            name: kubernetes
+      always:
+        - name: Reap the build-time containerd before teardown
+          ansible.builtin.shell: |
+            set -u
+            # Stop containerd, then wait for it to actually exit so its overlay
+            # snapshot mounts and content store are released before sysprep and
+            # DIB's chroot unmount run. Escalate to SIGKILL if it outlives ~30s.
+            pkill -TERM -f '/usr/local/bin/containerd' || true
+            for _ in $(seq 30); do
+                pgrep -f '/usr/local/bin/containerd' >/dev/null 2>&1 || break
+                sleep 1
+            done
+            if pgrep -f '/usr/local/bin/containerd' >/dev/null 2>&1; then
+                pkill -KILL -f '/usr/local/bin/containerd' || true
+                rm -f /var/run/containerd/containerd.sock
+            fi
+          args:
+            executable: /bin/bash
+          changed_when: true
+        - name: Wait for the containerd socket to be released
+          ansible.builtin.wait_for:
+            path: /var/run/containerd/containerd.sock
+            state: absent
+            timeout: 30
+
+    - name: Include sysprep role
+      ansible.builtin.include_role:
+        name: sysprep
+
+  environment:
+    http_proxy: "{{ http_proxy | default('') }}"
+    https_proxy: "{{ https_proxy | default('') }}"
+    no_proxy: "{{ no_proxy | default('') }}"
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
+    PYTHONPATH: "{{ python_path | default(omit) }}"

--- a/overrides/v1.33-gardener.json
+++ b/overrides/v1.33-gardener.json
@@ -1,0 +1,7 @@
+{
+    "containerd_version": "1.7.30",
+    "kubernetes_deb_version": "1.33.12-1.1",
+    "kubernetes_semver": "v1.33.12",
+    "kubernetes_series": "v1.33",
+    "runc_version": "1.4.0"
+}

--- a/overrides/v1.33.json
+++ b/overrides/v1.33.json
@@ -1,0 +1,5 @@
+{
+    "kubernetes_deb_version": "1.33.12-1.1",
+    "kubernetes_semver": "v1.33.12",
+    "kubernetes_series": "v1.33"
+}

--- a/overrides/v1.34-gardener.json
+++ b/overrides/v1.34-gardener.json
@@ -1,0 +1,7 @@
+{
+    "containerd_version": "1.7.30",
+    "kubernetes_deb_version": "1.34.8-1.1",
+    "kubernetes_semver": "v1.34.8",
+    "kubernetes_series": "v1.34",
+    "runc_version": "1.4.0"
+}

--- a/overrides/v1.34.json
+++ b/overrides/v1.34.json
@@ -1,0 +1,5 @@
+{
+    "kubernetes_deb_version": "1.34.8-1.1",
+    "kubernetes_semver": "v1.34.8",
+    "kubernetes_series": "v1.34"
+}

--- a/overrides/v1.35-gardener.json
+++ b/overrides/v1.35-gardener.json
@@ -1,0 +1,7 @@
+{
+    "containerd_version": "1.7.30",
+    "kubernetes_deb_version": "1.35.5-1.1",
+    "kubernetes_semver": "v1.35.5",
+    "kubernetes_series": "v1.35",
+    "runc_version": "1.4.0"
+}

--- a/overrides/v1.35.json
+++ b/overrides/v1.35.json
@@ -1,0 +1,5 @@
+{
+    "kubernetes_deb_version": "1.35.5-1.1",
+    "kubernetes_semver": "v1.35.5",
+    "kubernetes_series": "v1.35"
+}

--- a/overrides/v1.36-gardener.json
+++ b/overrides/v1.36-gardener.json
@@ -1,0 +1,7 @@
+{
+    "containerd_version": "1.7.30",
+    "kubernetes_deb_version": "1.36.1-1.1",
+    "kubernetes_semver": "v1.36.1",
+    "kubernetes_series": "v1.36",
+    "runc_version": "1.4.0"
+}

--- a/overrides/v1.36.json
+++ b/overrides/v1.36.json
@@ -1,0 +1,5 @@
+{
+    "kubernetes_deb_version": "1.36.1-1.1",
+    "kubernetes_semver": "v1.36.1",
+    "kubernetes_series": "v1.36"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+diskimage-builder==3.41.0


### PR DESCRIPTION
Closes #333

## Summary

Replaces the Packer/image-builder local build with a `disk-image-create`-based build that produces the same `ubuntu-2404-kube-vX.YY` qcow2 images. A custom `k8s-capi` DIB element fetches `kubernetes-sigs/image-builder` at a pinned git ref, installs Ansible in the chroot, and runs image-builder's own roles unchanged — `node`→`setup`, `providers`, `containerd`, `kubernetes`, `sysprep` — in their original order, rather than reimplementing them in Bash.

The core problem this solves: image-builder's roles assume a booted VM, but the DIB chroot has no running systemd. The element supplies build-time shims prepended to `PATH` only during the Ansible run, plus a `policy-rc.d` during apt phases, so daemon-touching tasks succeed while still writing their config files. For the Kubernetes image pre-pull, containerd is started manually in the chroot so images bake into the offline content store, then stopped.

## Change set (commit order)

1. **`a01d8ab` Pin diskimage-builder in requirements.txt** — Establishes the `diskimage-builder` toolchain pin the build depends on, mirroring the version used across OSISM image repositories.

2. **`784a31b` Add k8s-capi DIB element scaffold and metadata** — The element skeleton: `package-installs.yaml` dependencies for the in-chroot Ansible run, the two `DIB_*` inputs (`environment.d/10-k8s-capi.bash`) selecting the image-builder ref and the per-series override, `element-deps`, and a `README.rst` documenting the element, its shim mechanism, and the manual containerd pre-pull.

3. **`b17c3f6` Add systemd-less build shims for k8s-capi element** — The six shims prepended to `PATH` during the Ansible run (`static/shims/`). The `systemctl` shim performs `enable`/`disable` offline and no-ops daemon lifecycle/status verbs; `modprobe`, `sysctl`, `journalctl`, `fstrim`, and `udevadm` are no-ops, so the roles still write their config files while the live kernel/daemon action is skipped.

4. **`091a7a6` Add wrapper playbook running image-builder roles** — `static/wrapper.yml` mirrors image-builder's `node.yml` play header and runs its roles unchanged in order: `node` (which pulls in `setup`), `providers`, `containerd`, `kubernetes`, `sysprep`. A manual containerd start/wait/stop brackets the `kubernetes` role so kubeadm's offline image pre-pull bakes images into the content store in the systemd-less chroot.

5. **`f6139a7` Fetch and stage image-builder in extra-data.d** — `extra-data.d/10-fetch-image-builder` clones `kubernetes-sigs/image-builder` at the pinned ref and stages its ansible tree, config JSONs, the wrapper, shims, and the selected override under `$TMP_HOOKS_PATH` for the chroot. The config JSONs are normalized by rewriting Packer `{{ user \`x\` }}` to Ansible `{{ x }}` and JSON `null` to `""`, so a direct `ansible-playbook` run matches Packer's handling (`containerd_additional_settings` is b64decoded and would fail on `None`).

6. **`060f6e9` Install Ansible and run image-builder in install.d** — `install.d/50-install-ansible` builds a throwaway venv with image-builder's pinned `ansible-core` plus the `community.general`/`ansible.posix` collections; `install.d/60-run-image-builder` runs `wrapper.yml` with the staged config JSONs and override. A `policy-rc.d` and the shims on `PATH` let daemon-touching tasks succeed in the chroot; the override is loaded last so its Kubernetes/containerd/runc versions win.

7. **`6d2bbbf` Clean up build scaffolding in cleanup.d** — `cleanup.d/90-k8s-capi-cleanup` removes the `policy-rc.d`, the staged image-builder tree and venv, and the Ansible/pip caches so no build scaffolding ships in the image. The roles' own outputs (binaries, configs, pre-pulled images) live elsewhere on the root filesystem and are kept.

8. **`b8a8673` Add per-series and gardener override files** — `overrides/` Kubernetes/gardener override files for each supported series (v1.33–v1.36). Non-gardener files set the Kubernetes deb version, semver, and series; the `-gardener` variants also pin containerd 1.7.30 and runc 1.4.0. No ISO or output handling is included.

9. **`e778d84` Replace build-local.sh with DIB local build** — Replaces the Packer wrapper with a `disk-image-create` build. It maps a `VERSION` argument (e.g. `v1.33` or `v1.36-gardener`) to an override, sets the `DIB_*` inputs, builds a venv from `requirements.txt`, and runs `disk-image-create` with the `ubuntu`/`vm`/`growroot`/`openssh-server`/`k8s-capi` elements to produce `ubuntu-2404-kube-<semver>` qcow2 images.

## Notes on scope / divergence from the issue

- Scope matches the issue: per-series overrides cover v1.33–v1.36 and their gardener variants, with Kubernetes and gardener vars only — no ISO handling, no CI/publishing wiring (those are downstream of #332).
- Parity is verified by booting in qemu or offline inspection of installed component versions, containerd/CNI/crictl/sysctl/modules config, and pre-pulled images; this PR stands up the build and does not itself add automated parity tests.

---

_Implemented by [planwerk-agent](https://github.com/planwerk/planwerk-agent) 84299e2 with Claude:claude-opus-4-8_
